### PR TITLE
coerce package_version elements in localResults metadata to character

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: alabaster.sfe
 Type: Package
 Title: Language agnostic on disk serialization of SpatialFeatureExperiment
-Version: 0.99.2
+Version: 0.99.2001
 Authors@R: 
     person("Lambda", "Moses", email = "dl3764@columbia.edu", 
     role = c("aut", "cre"),

--- a/R/saveSFE.R
+++ b/R/saveSFE.R
@@ -23,6 +23,10 @@
     # One directory for each type, and inside that one for each feature
     # Need to deal with illegal names at some point
     if (!length(lrs)) return(NULL)
+    # deal with package_version VJC
+    availlr = names(metadata(lrs)$params)
+    for (i in availlr)
+        metadata(lrs)$params[[i]]$version = as.character(metadata(lrs)$params[[i]]$version)
     message(">>> Saving localResults")
     dir_use <- file.path(path, "local_results")
     altSaveObject(lrs, dir_use)


### PR DESCRIPTION
This is a very trivial modification to avoid an error when trying to serialize an object containing an instance of package_version.

I think the technical debt incurred is small.  We will discuss the issue in the Feb 2025 Tech Advisory Board to see if we want to put some effort into solving this.